### PR TITLE
change repo links to web links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,41 +5,41 @@ A publicly compiled list of tech conferences that offer childcare.
 
 | Conference Name | Location | Is childcare free? |
 | ------------- | -------------| ------------- |
-| [Revolution Conf](revolutionconf.com) | Virginia Beach, VA, USA | ? |
-| [GetConf](getconfomaha.com) | Omaha, NE, USA | ? | 
-| [PyCascades](2020.pycascades.com) | Pacific Northwest, USA | ? | 
+| [Revolution Conf](https://revolutionconf.com) | Virginia Beach, VA, USA | ? |
+| [GetConf](https://getconfomaha.com) | Omaha, NE, USA | ? | 
+| [PyCascades](https://2020.pycascades.com) | Pacific Northwest, USA | ? | 
 | [Node+JS Interactive](https://events19.linuxfoundation.org/events/nodejs-interactive-2019/) | Montreal, Canada | ? | 
 | [OSCON](https://conferences.oreilly.com/oscon/oscon-or) | Portland, OR, USA | ? | 
-| [Beer City Code](beercitycode.com) | Grand Rapids, MI, USA | ? | 
+| [Beer City Code](https://beercitycode.com) | Grand Rapids, MI, USA | ? | 
 | [Rust Conf](https://rustconf.com/) | Portland, OR, USA | ? | 
 | [WordCamp London](https://2020.london.wordcamp.org/) | London, England | £5 | 
 | [WordCamp US](https://us.wordcamp.org/) | USA | Free | 
 | [WordCamp EU](https://europe.wordcamp.org/) | Europe | Free | 
-| [WordCamp Philly](2019.philadelphia.wordcamp.org) | USA | ? | 
-| [Codeland](codelandconf.com) | New York, NY, USA | ? | 
-| [Write/Speak/Code](writespeakcode.com) | NYC, SF, Chicago, LA, Seattle, & the World | ? | 
-| [RubyConf](rubyconf.org) | Nashville, TN, USA | Free | 
-| [RailsConf](railsconf.org) | Portland, OR, USA | Free | 
+| [WordCamp Philly](https://2019.philadelphia.wordcamp.org) | USA | ? | 
+| [Codeland](https://codelandconf.com) | New York, NY, USA | ? | 
+| [Write/Speak/Code](https://writespeakcode.com) | NYC, SF, Chicago, LA, Seattle, & the World | ? | 
+| [RubyConf](https://rubyconf.org) | Nashville, TN, USA | Free | 
+| [RailsConf](https://railsconf.org) | Portland, OR, USA | Free | 
 | [Linux Foundation Events](https://events.linuxfoundation.org) | Worldwide | ? | 
-| [Women Who Startup™](womenwhostartup.com) | Denver, CO, USA and Worldwide | Free | 
-| [Abstractions](abstractions.io) | Pittsburgh, PA, USA | Free | 
+| [Women Who Startup™](https://womenwhostartup.com) | Denver, CO, USA and Worldwide | Free | 
+| [Abstractions](https://abstractions.io) | Pittsburgh, PA, USA | Free | 
 | [PyCon](https://pycon.org/) | Worldwide | ? | 
 | [JSConf](https://jsconf.com/) | Worldwide | ? |
-| [CascadiaJS](2020.cascadiajs.com) | Seattle, WA, USA | ? |
-| [LambdaConf](lambdaconf.zohobackstage.com/LambdaConf2020) | Estes Park, CO, USA | ? |
-| [Stir Trek](stirtrek.com) | Columbus, OH, USA | ? |
-| [PyGotham](pygotham.org) | New York, NY, USA | ? |
-| [MageUnconference](mageunconference.org) | Germany | ? |
-| [HasGeek](hasgeek.com) | Bangalore, India | ? |
+| [CascadiaJS](https://2020.cascadiajs.com) | Seattle, WA, USA | ? |
+| [LambdaConf](https://lambdaconf.zohobackstage.com/LambdaConf2020) | Estes Park, CO, USA | ? |
+| [Stir Trek](https://stirtrek.com) | Columbus, OH, USA | ? |
+| [PyGotham](https://pygotham.org) | New York, NY, USA | ? |
+| [MageUnconference](https://mageunconference.org) | Germany | ? |
+| [HasGeek](https://hasgeek.com) | Bangalore, India | ? |
 | [Microsoft Build](https://www.microsoft.com/en-us/build) | Seattle, WA, USA | Free |
-| [React Rally](reactrally.com) | Salt Lake City, UT, USA | ? |
-| [North Bay Python](northbaypython.org) | Petaluma, CA, USA | Free |
-| [kawaiicon](kawaiicon.org) | Wellington City, New Zealand | ? |
-| [Kiwicon](KIWICON.ORG) | Wellington, New Zealand | ? |
-| [Kiwi Ruby](kiwi.ruby.nz) | Wellington, New Zealand | ? |
-| [FrOSCon](froscon.org) | Sankt Augustin, Deutschland | ? |
+| [React Rally](https://reactrally.com) | Salt Lake City, UT, USA | ? |
+| [North Bay Python](https://northbaypython.org) | Petaluma, CA, USA | Free |
+| [kawaiicon](https://kawaiicon.org) | Wellington City, New Zealand | ? |
+| [Kiwicon](https://KIWICON.ORG) | Wellington, New Zealand | ? |
+| [Kiwi Ruby](https://kiwi.ruby.nz) | Wellington, New Zealand | ? |
+| [FrOSCon](https://froscon.org) | Sankt Augustin, Deutschland | ? |
 | [Lead Dev](https://theleaddeveloper.com/) | Berlin, NYC, London, SF | ? |
-| [ng-conf](ng-conf.org) | Salt Lake City, UT, USA | ? |
+| [ng-conf](https://ng-conf.org) | Salt Lake City, UT, USA | ? |
 | [DjangoCon US](https://2019.djangocon.us/) | San Diego, CA, USA | Not Free, but info provided |
 | [Test Bash](https://www.ministryoftesting.com/testbash) | Brighton, Detroit, Netherlands | ? |
 | [DevOpsDays MSP](https://devopsdays.org/events/2019-minneapolis/welcome/) | Minneapolis, MN, USA | ? |


### PR DESCRIPTION
Leaving off the `https://` causes GitHub to route md links as subpages to your repo, rather than The Internet. This PR adds `https://` to the links that were missing them.